### PR TITLE
Ability to disable the sticky keyword from a pillar.

### DIFF
--- a/sslloadbalancer/map.jinja
+++ b/sslloadbalancer/map.jinja
@@ -2,6 +2,7 @@
     'Debian': {
       'loadbalancers': {
         'front': {
+          'sticky': True,
           'https_port': None,
           'servers': [],
         }

--- a/sslloadbalancer/templates/sslloadbalancer.conf
+++ b/sslloadbalancer/templates/sslloadbalancer.conf
@@ -1,11 +1,18 @@
 {% from 'sslloadbalancer/map.jinja' import nginx with context %}
 
 upstream backend {
-    {% for server in nginx.loadbalancers.front.servers %}
+    {% for server in nginx.loadbalancers.front.servers -%}
     server {{server}};
-    {% endfor %}
+    {% endfor -%}
 
+    {# Add sticky keyword if non_sticky is False or doesn't exist -#}
+    {% if nginx.loadbalancers.non_sticky is defined -%}
+      {% if not nginx.loadbalancers.non_sticky -%}
+    sticky
+      {% endif -%}
+    {% else -%}
     sticky;
+    {% endif -%}
 }
 
 

--- a/sslloadbalancer/templates/sslloadbalancer.conf
+++ b/sslloadbalancer/templates/sslloadbalancer.conf
@@ -5,12 +5,8 @@ upstream backend {
     server {{server}};
     {% endfor -%}
 
-    {# Add sticky keyword if non_sticky is False or doesn't exist -#}
-    {% if nginx.loadbalancers.non_sticky is defined -%}
-      {% if not nginx.loadbalancers.non_sticky -%}
-    sticky
-      {% endif -%}
-    {% else -%}
+    {# Add sticky keyword to toggle sticky sessions -#}
+    {% if nginx.loadbalancers.front.get("sticky", True) -%}
     sticky;
     {% endif -%}
 }


### PR DESCRIPTION
This change introduces the keyword non_sticky, which has to be True in order to disable sticky sessions in the upstream. If set to False or missing then the sessions will be sticky.

I aknowledge the fact that it's a bit strange to negate a negation, but it was done this way to keep backwards compatibility and avoid the famous wrath of the @kyriakosoikonomakos 